### PR TITLE
Fix tox summary

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SQOUnified
 Type: Package
 Title: Tools for calculating SQO scores based on three Lines of Evidence (Benthic, Tox, Chem)
-Version: 0.7.0
+Version: 0.7.1
 Date: 2024-08-28
 Description: Calculates Site Assessments based on the three lines of evidence as outlined in the CASQO Manual
             Benthic, Toxicity, and Chemistry

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,6 @@ Imports:
   tidyr,
   lubridate,
   DT,
-  tidyverse,
   knitr,
   rmarkdown
 Depends: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SQOUnified
 Type: Package
 Title: Tools for calculating SQO scores based on three Lines of Evidence (Benthic, Tox, Chem)
-Version: 0.8.0
+Version: 0.8.1
 Date: 2024-08-28
 Description: Calculates Site Assessments based on the three lines of evidence as outlined in the CASQO Manual
             Benthic, Toxicity, and Chemistry

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SQOUnified
 Type: Package
 Title: Tools for calculating SQO scores based on three Lines of Evidence (Benthic, Tox, Chem)
-Version: 0.7.1
+Version: 0.8.0
 Date: 2024-08-28
 Description: Calculates Site Assessments based on the three lines of evidence as outlined in the CASQO Manual
             Benthic, Toxicity, and Chemistry

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SQOUnified
 Type: Package
 Title: Tools for calculating SQO scores based on three Lines of Evidence (Benthic, Tox, Chem)
-Version: 0.6.6
+Version: 0.7.0
 Date: 2024-08-28
 Description: Calculates Site Assessments based on the three lines of evidence as outlined in the CASQO Manual
             Benthic, Toxicity, and Chemistry

--- a/R/BRI.R
+++ b/R/BRI.R
@@ -60,7 +60,7 @@
 #' @importFrom dplyr left_join filter rename select mutate group_by summarize summarise case_when
 #'
 #' @export
-BRI <- function(BenthicData, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'BRIlog.Rmd'), verbose = F)
+BRI <- function(BenthicData, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'BRIlog.Rmd'), verbose = F, knitlog = F)
 {
   # This (as of now) is the main function used by the R package
 
@@ -295,9 +295,28 @@ BRI <- function(BenthicData, logfile = file.path(getwd(), 'logs', format(Sys.tim
   )
   create_download_link(data = bri_final, logfile = logfile, filename = 'BRI-final.csv', linktext = 'Download BRI Final Step', verbose = verbose)
 
-
-
   writelog('\n### END: BRI function.\n', logfile = logfile, verbose = verbose)
+
+  if (verbose && knitlog) {
+    if ( tolower(tools::file_ext(logfile)) =='rmd' ) {
+
+      html_file <- sub("\\.Rmd$", ".html", logfile, ignore.case = TRUE)
+
+      print(paste0("Rendering ", logfile, " to ", html_file))
+      rmarkdown::render(
+        input = logfile,
+        output_file = html_file,
+        output_format = "html_document",
+        quiet = TRUE
+      )
+      print("Done")
+
+    } else {
+      fn_name <- as.character(sys.call()[[1]])
+      warning(paste0("In '", fn_name, "': knitlog = TRUE but the logfile is not an R Markdown (.Rmd) file. Skipping knitting."))
+    }
+  }
+
 
   return(bri_final)
 }

--- a/R/IBI.R
+++ b/R/IBI.R
@@ -71,7 +71,7 @@
 #
 ##########################################################################################################################
 #' @export
-IBI <- function(BenthicData, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'IBIlog.Rmd'), verbose = F)
+IBI <- function(BenthicData, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'IBIlog.Rmd'), verbose = F, knitlog = F)
 {
 
   # Initialize Logging
@@ -404,6 +404,25 @@ IBI <- function(BenthicData, logfile = file.path(getwd(), 'logs', format(Sys.tim
   )
   create_download_link(data = ibi_final, logfile = logfile, filename = 'IBI-final-scores.csv', linktext = 'Download final IBI scores', verbose = verbose)
 
+  if (verbose && knitlog) {
+    if ( tolower(tools::file_ext(logfile)) == 'rmd' ) {
+
+      html_file <- sub("\\.Rmd$", ".html", logfile, ignore.case = TRUE)
+
+      print(paste0("Rendering ", logfile, " to ", html_file))
+      rmarkdown::render(
+        input = logfile,
+        output_file = html_file,
+        output_format = "html_document",
+        quiet = TRUE
+      )
+      print("Done")
+
+    } else {
+      fn_name <- as.character(sys.call()[[1]])
+      warning(paste0("In '", fn_name, "': knitlog = TRUE but the logfile is not an R Markdown (.Rmd) file. Skipping knitting."))
+    }
+  }
 
 
   writelog('\n### END: IBI function.\n', logfile = logfile, verbose = verbose)

--- a/R/MAMBI.R
+++ b/R/MAMBI.R
@@ -94,7 +94,7 @@
 #' @importFrom purrr map_dfr
 #' @export
 
-MAMBI<-function(BenthicData, EG_Ref_values = NULL, EG_Scheme="Hybrid", logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'MAMBI_Log.Rmd' ), verbose = F)
+MAMBI<-function(BenthicData, EG_Ref_values = NULL, EG_Scheme="Hybrid", logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'MAMBI_Log.Rmd' ), verbose = F, knitlog = F)
 {
 
   # Initialize Logging
@@ -418,6 +418,26 @@ MAMBI<-function(BenthicData, EG_Ref_values = NULL, EG_Scheme="Hybrid", logfile =
       #rename(B13_Stratum = Stratum) %>%
       bind_rows(.,azoic.samples) %>%
       mutate(Index = "M-AMBI")
+  }
+
+  if (verbose && knitlog) {
+    if ( tolower(tools::file_ext(logfile)) == 'rmd' ) {
+
+      html_file <- sub("\\.Rmd$", ".html", logfile, ignore.case = TRUE)
+
+      print(paste0("Rendering ", logfile, " to ", html_file))
+      rmarkdown::render(
+        input = logfile,
+        output_file = html_file,
+        output_format = "html_document",
+        quiet = TRUE
+      )
+      print("Done")
+
+    } else {
+      fn_name <- as.character(sys.call()[[1]])
+      warning(paste0("In '", fn_name, "': knitlog = TRUE but the logfile is not an R Markdown (.Rmd) file. Skipping knitting."))
+    }
   }
 
   return(Overall.Results)

--- a/R/RBI.R
+++ b/R/RBI.R
@@ -139,7 +139,7 @@
 #' @export
 
 # RBI ----
-RBI <- function(BenthicData, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'RBIlog.Rmd'), verbose = F)
+RBI <- function(BenthicData, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'RBIlog.Rmd'), verbose = F, knitlog = F)
 {
 
   # Initialize Logging
@@ -553,6 +553,26 @@ RBI <- function(BenthicData, logfile = file.path(getwd(), 'logs', format(Sys.tim
 
 
   writelog('\n### END: RBI function.\n', logfile = logfile, verbose = verbose)
+
+  if (verbose && knitlog) {
+    if ( tolower(tools::file_ext(logfile)) == 'rmd' ) {
+
+      html_file <- sub("\\.Rmd$", ".html", logfile, ignore.case = TRUE)
+
+      print(paste0("Rendering ", logfile, " to ", html_file))
+      rmarkdown::render(
+        input = logfile,
+        output_file = html_file,
+        output_format = "html_document",
+        quiet = TRUE
+      )
+      print("Done")
+
+    } else {
+      fn_name <- as.character(sys.call()[[1]])
+      warning(paste0("In '", fn_name, "': knitlog = TRUE but the logfile is not an R Markdown (.Rmd) file. Skipping knitting."))
+    }
+  }
 
   return(rbi_scores)
 

--- a/R/RIVPACS.R
+++ b/R/RIVPACS.R
@@ -44,7 +44,7 @@
 
 #---- RIVPACS WRAPPER FUNCTION ----
 # This is what we will use for RIVPACS
-RIVPACS <- function(benthic_data, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'log.txt' ), verbose = F){
+RIVPACS <- function(benthic_data, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'log.txt' ), verbose = F, knitlog = F){
 
   # Initialize Logging
   logfile.type <- ifelse(tolower(tools::file_ext(logfile)) == 'rmd', 'RMarkdown', 'text')
@@ -458,6 +458,25 @@ RIVPACS <- function(benthic_data, logfile = file.path(getwd(), 'logs', format(Sy
 
   writelog('\n### END: RIVPACS function.\n', logfile = logfile, verbose = verbose)
 
+  if (verbose && knitlog) {
+    if ( tolower(tools::file_ext(logfile)) == 'rmd' ) {
+
+      html_file <- sub("\\.Rmd$", ".html", logfile, ignore.case = TRUE)
+
+      print(paste0("Rendering ", logfile, " to ", html_file))
+      rmarkdown::render(
+        input = logfile,
+        output_file = html_file,
+        output_format = "html_document",
+        quiet = TRUE
+      )
+      print("Done")
+
+    } else {
+      fn_name <- as.character(sys.call()[[1]])
+      warning(paste0("In '", fn_name, "': knitlog = TRUE but the logfile is not an R Markdown (.Rmd) file. Skipping knitting."))
+    }
+  }
 
   return(rivpacs.score)
 }
@@ -476,7 +495,8 @@ SoCalRivpacs <- function(Pcutoff = 0.5,
                          reference.cov = socal.reference.covariance,
                          observed.taxa = socal.example.taxa,
                          logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'log.txt' ),
-                         verbose = F
+                         verbose = F,
+                         knitlog = F
                          ) {
 
   writelog('\n##### **BEGIN**: So Cal RIVPACS function.\n', logfile = logfile, verbose = verbose)
@@ -1336,6 +1356,26 @@ SoCalRivpacs <- function(Pcutoff = 0.5,
 
 
   writelog('\n#### **END**: So Cal RIVPACS function.\n  \n  ', logfile = logfile, verbose = verbose)
+
+  if (verbose && knitlog) {
+    if ( tolower(tools::file_ext(logfile)) == 'rmd' ) {
+
+      html_file <- sub("\\.Rmd$", ".html", logfile, ignore.case = TRUE)
+
+      print(paste0("Rendering ", logfile, " to ", html_file))
+      rmarkdown::render(
+        input = logfile,
+        output_file = html_file,
+        output_format = "html_document",
+        quiet = TRUE
+      )
+      print("Done")
+
+    } else {
+      fn_name <- as.character(sys.call()[[1]])
+      warning(paste0("In '", fn_name, "': knitlog = TRUE but the logfile is not an R Markdown (.Rmd) file. Skipping knitting."))
+    }
+  }
 
   return(results)
 

--- a/R/SQOUnified.R
+++ b/R/SQOUnified.R
@@ -86,7 +86,7 @@
 
 
 #' @export
-SQOUnified <- function(benthic = NULL, chem = NULL, tox = NULL, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'log.Rmd' ), verbose = F) {
+SQOUnified <- function(benthic = NULL, chem = NULL, tox = NULL, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'log.Rmd' ), verbose = F, knitlog = F) {
 
   # Initialize Logging
   logfile.type <- ifelse(tolower(tools::file_ext(logfile)) == 'rmd', 'RMarkdown', 'text')
@@ -117,7 +117,7 @@ SQOUnified <- function(benthic = NULL, chem = NULL, tox = NULL, logfile = file.p
 
     init.log(benthiclogfile, base.func.name = sys.call(), type = 'RMarkdown', current.time = Sys.time(), is.base.func = length(sys.calls()) == 1, verbose = verbose, libraries = benthiclibs)
 
-    benthic <- benthic.sqo(benthic, logfile = benthiclogfile, verbose = verbose) %>%
+    benthic <- benthic.sqo(benthic, logfile = benthiclogfile, verbose = verbose, knitlog = knitlog) %>%
       mutate(LOE = 'Benthic') %>%
       select(StationID, Replicate, SampleDate, LOE, Index, Score, Category, `Category Score`) %>%
       # David says only keep replicate 1.
@@ -156,7 +156,7 @@ SQOUnified <- function(benthic = NULL, chem = NULL, tox = NULL, logfile = file.p
 
     init.log(chemlogfile, base.func.name = sys.call(), type = 'RMarkdown', current.time = Sys.time(), is.base.func = length(sys.calls()) == 1, verbose = verbose, libraries = chemlibs)
 
-    chem <- chem.sqo(chem, logfile = chemlogfile, verbose = verbose) %>%
+    chem <- chem.sqo(chem, logfile = chemlogfile, verbose = verbose, knitlog = knitlog) %>%
       mutate(LOE = 'Chemistry') %>%
       select(StationID, LOE, Index, Score, Category, `Category Score`)
 
@@ -181,7 +181,7 @@ SQOUnified <- function(benthic = NULL, chem = NULL, tox = NULL, logfile = file.p
 
     init.log(toxlogfile, base.func.name = sys.call(), type = 'RMarkdown', current.time = Sys.time(), is.base.func = length(sys.calls()) == 1, verbose = verbose, libraries = toxlibs)
 
-    tox <- tox.sqo(tox, logfile = toxlogfile, verbose = verbose) %>%
+    tox <- tox.sqo(tox, logfile = toxlogfile, verbose = verbose, knitlog = knitlog) %>%
       mutate(LOE = 'Toxicity') %>%
       select(StationID, LOE, Index, Score, Category, `Category Score`)
 
@@ -241,6 +241,8 @@ SQOUnified <- function(benthic = NULL, chem = NULL, tox = NULL, logfile = file.p
   )
 
   writelog('Done computing ALL SQO scores', logfile = logfile, verbose = verbose)
+
+  # Not worth knitting the main SQOUnified log to HTML, as it just tells them to look at the subfolders
 
   return(out)
 

--- a/R/SQOUnified.R
+++ b/R/SQOUnified.R
@@ -135,6 +135,8 @@ SQOUnified <- function(benthic = NULL, chem = NULL, tox = NULL, logfile = file.p
       # The Bight program however, which only samples every 5 years, puts the year of the sample in the stationid
       select(-c(Replicate,SampleDate))
 
+    writelog('See the Benthic subdirectory for the benthic SQO logs', logfile = logfile, verbose = verbose)
+
   } else {
     benthic = data.frame(
       StationID = c(),
@@ -157,6 +159,9 @@ SQOUnified <- function(benthic = NULL, chem = NULL, tox = NULL, logfile = file.p
     chem <- chem.sqo(chem, logfile = chemlogfile, verbose = verbose) %>%
       mutate(LOE = 'Chemistry') %>%
       select(StationID, LOE, Index, Score, Category, `Category Score`)
+
+    writelog('See the Chemistry subdirectory for the chemistry SQO logs', logfile = logfile, verbose = verbose)
+
   } else {
     chem = data.frame(
       StationID = c(),
@@ -179,6 +184,9 @@ SQOUnified <- function(benthic = NULL, chem = NULL, tox = NULL, logfile = file.p
     tox <- tox.sqo(tox, logfile = toxlogfile, verbose = verbose) %>%
       mutate(LOE = 'Toxicity') %>%
       select(StationID, LOE, Index, Score, Category, `Category Score`)
+
+    writelog('See the Toxicity subdirectory for the toxicity SQO logs', logfile = logfile, verbose = verbose)
+
   } else {
     tox <- data.frame(
       StationID = c(),

--- a/R/benthic.R
+++ b/R/benthic.R
@@ -42,7 +42,7 @@
 #'
 #' @export
 
-benthic.sqo <- function(benthic_data, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'benthiclog.Rmd' ), verbose = F){
+benthic.sqo <- function(benthic_data, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'benthiclog.Rmd' ), verbose = F, knitlog = F){
 
   # Initialize Logging
   logfile.type <- ifelse(tolower(tools::file_ext(logfile)) == 'rmd', 'RMarkdown', 'text')
@@ -328,6 +328,26 @@ benthic.sqo <- function(benthic_data, logfile = file.path(getwd(), 'logs', forma
 
 
   writelog('\n# END: Benthic SQO function.\n', logfile = logfile, verbose = verbose)
+
+  if (verbose && knitlog) {
+    if ( tolower(tools::file_ext(logfile)) =='rmd' ) {
+
+      html_file <- sub("\\.Rmd$", ".html", logfile, ignore.case = TRUE)
+
+      print(paste0("Rendering ", logfile, " to ", html_file))
+      rmarkdown::render(
+        input = logfile,
+        output_file = html_file,
+        output_format = "html_document",
+        quiet = TRUE
+      )
+      print("Done")
+
+    } else {
+      fn_name <- as.character(sys.call()[[1]])
+      warning(paste0("In '", fn_name, "': knitlog = TRUE but the logfile is not an R Markdown (.Rmd) file. Skipping knitting."))
+    }
+  }
 
   return(final.scores)
 

--- a/R/chemistry.R
+++ b/R/chemistry.R
@@ -34,7 +34,7 @@
 #'
 #' @import dplyr
 #' @export
-LRM <- function(chemdata.lrm.input, preprocessed = F, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'chemlog.Rmd' ), verbose = F)  {
+LRM <- function(chemdata.lrm.input, preprocessed = F, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'chemlog.Rmd' ), verbose = F, knitlog = F)  {
   "lrm_table"
 
   # Initialize Logging
@@ -435,9 +435,30 @@ LRM <- function(chemdata.lrm.input, preprocessed = F, logfile = file.path(getwd(
 
   writelog("##### END Chem LRM Function\n", logfile = logfile, verbose = verbose)
 
+
+  if (verbose && knitlog) {
+    if ( tolower(tools::file_ext(logfile)) =='rmd' ) {
+
+      html_file <- sub("\\.Rmd$", ".html", logfile, ignore.case = TRUE)
+
+      print(paste0("Rendering ", logfile, " to ", html_file))
+      rmarkdown::render(
+        input = logfile,
+        output_file = html_file,
+        output_format = "html_document",
+        quiet = TRUE
+      )
+      print("Done")
+
+    } else {
+      fn_name <- as.character(sys.call()[[1]])
+      warning(paste0("In '", fn_name, "': knitlog = TRUE but the logfile is not an R Markdown (.Rmd) file. Skipping knitting."))
+    }
+  }
+
+
   return(chemdata_lrm.final)
 
-# uncomment to make the above block a function again
 }
 
 
@@ -476,7 +497,7 @@ LRM <- function(chemdata.lrm.input, preprocessed = F, logfile = file.path(getwd(
 #'
 #' @import dplyr
 #' @export
-CSI <- function(chemdata.csi.input, preprocessed = F, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'chemlog.Rmd' ), verbose = F) {
+CSI <- function(chemdata.csi.input, preprocessed = F, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'chemlog.Rmd' ), verbose = F, knitlog = F) {
   "csi_weight"
 
   # Initialize Logging
@@ -959,6 +980,28 @@ CSI <- function(chemdata.csi.input, preprocessed = F, logfile = file.path(getwd(
   # Serve it up for download
   create_download_link(data = chemdata_csi.final, logfile = logfile, filename = 'CSI_Final.csv', linktext = 'Download CSI Final (Final DataFrame within CSI Function)', verbose = verbose)
 
+
+  if (verbose && knitlog) {
+    if ( tolower(tools::file_ext(logfile)) =='rmd' ) {
+
+      html_file <- sub("\\.Rmd$", ".html", logfile, ignore.case = TRUE)
+
+      print(paste0("Rendering ", logfile, " to ", html_file))
+      rmarkdown::render(
+        input = logfile,
+        output_file = html_file,
+        output_format = "html_document",
+        quiet = TRUE
+      )
+      print("Done")
+
+    } else {
+      fn_name <- as.character(sys.call()[[1]])
+      warning(paste0("In '", fn_name, "': knitlog = TRUE but the logfile is not an R Markdown (.Rmd) file. Skipping knitting."))
+    }
+  }
+
+
   return(chemdata_csi.final)
 }
 
@@ -997,7 +1040,7 @@ CSI <- function(chemdata.csi.input, preprocessed = F, logfile = file.path(getwd(
 #'
 #' @import dplyr
 #' @export
-chem.sqo <- function(chemdata, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'chemlog.Rmd' ), verbose = F, logtitle = 'Chemistry SQO Logs') {
+chem.sqo <- function(chemdata, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'chemlog.Rmd' ), verbose = F, logtitle = 'Chemistry SQO Logs', knitlog = F) {
 
   # ---- Initialize Logging ----
   logfile.type <- ifelse(tolower(tools::file_ext(logfile)) == 'rmd', 'RMarkdown', 'text')
@@ -1291,6 +1334,26 @@ chem.sqo <- function(chemdata, logfile = file.path(getwd(), 'logs', format(Sys.t
 
   writelog("\n# END Chem SQO Function\n", logfile = logfile, verbose = verbose)
 
+  if (verbose && knitlog) {
+    if ( tolower(tools::file_ext(logfile)) == 'rmd' ) {
+
+      html_file <- sub("\\.Rmd$", ".html", logfile, ignore.case = TRUE)
+
+      print(paste0("Rendering ", logfile, " to ", html_file))
+      rmarkdown::render(
+        input = logfile,
+        output_file = html_file,
+        output_format = "html_document",
+        quiet = TRUE
+      )
+      print("Done")
+
+    } else {
+      fn_name <- as.character(sys.call()[[1]])
+      warning(paste0("In '", fn_name, "': knitlog = TRUE but the logfile is not an R Markdown (.Rmd) file. Skipping knitting."))
+    }
+  }
+
   return(combined.final)
 
 }
@@ -1335,7 +1398,7 @@ chem.sqo <- function(chemdata, logfile = file.path(getwd(), 'logs', format(Sys.t
 #'
 #' @import dplyr
 #' @export
-chemdata_prep <- function(chemdata_prep.input, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'chemlog.Rmd' ), verbose = F){
+chemdata_prep <- function(chemdata_prep.input, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'chemlog.Rmd' ), verbose = F, knitlog = F){
 
   # Initialize Logging
   logfile.type <- ifelse(tolower(tools::file_ext(logfile)) == 'rmd', 'RMarkdown', 'text')
@@ -2254,6 +2317,28 @@ chemdata_prep <- function(chemdata_prep.input, logfile = file.path(getwd(), 'log
 
 
   writelog("\n#### END Function: chemdata_prep\n", logfile = logfile, verbose = verbose)
+
+
+  if (verbose && knitlog) {
+    if ( tolower(tools::file_ext(logfile)) == 'rmd' ) {
+
+      html_file <- sub("\\.Rmd$", ".html", logfile, ignore.case = TRUE)
+
+      print(paste0("Rendering ", logfile, " to ", html_file))
+      rmarkdown::render(
+        input = logfile,
+        output_file = html_file,
+        output_format = "html_document",
+        quiet = TRUE
+      )
+      print("Done")
+
+    } else {
+      fn_name <- as.character(sys.call()[[1]])
+      warning(paste0("In '", fn_name, "': knitlog = TRUE but the logfile is not an R Markdown (.Rmd) file. Skipping knitting."))
+    }
+  }
+
 
 
   return(chemdata.preprocessed.final)

--- a/R/chemistry.R
+++ b/R/chemistry.R
@@ -474,6 +474,7 @@ LRM <- function(chemdata.lrm.input, preprocessed = F, logfile = file.path(getwd(
 #' data(chem_sampledata) # load sample data to your environment
 #' CSI(chem_sampledata) # get scores and see output
 #'
+#' @import dplyr
 #' @export
 CSI <- function(chemdata.csi.input, preprocessed = F, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'chemlog.Rmd' ), verbose = F) {
   "csi_weight"
@@ -994,6 +995,7 @@ CSI <- function(chemdata.csi.input, preprocessed = F, logfile = file.path(getwd(
 #' data(chem_sampledata) # load sample data to your environment
 #' chem.sqo(chem_sampledata) # get scores and see output
 #'
+#' @import dplyr
 #' @export
 chem.sqo <- function(chemdata, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'chemlog.Rmd' ), verbose = F, logtitle = 'Chemistry SQO Logs') {
 
@@ -1331,6 +1333,7 @@ chem.sqo <- function(chemdata, logfile = file.path(getwd(), 'logs', format(Sys.t
 #' data(chem_sampledata) # load sample data to your environment
 #' chemdata_prep(chem_sampledata) # get scores and see output
 #'
+#' @import dplyr
 #' @export
 chemdata_prep <- function(chemdata_prep.input, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'chemlog.Rmd' ), verbose = F){
 

--- a/R/chemistry.R
+++ b/R/chemistry.R
@@ -88,7 +88,7 @@ LRM <- function(chemdata.lrm.input, preprocessed = F, logfile = file.path(getwd(
     writelog(
       "\n#### Chemdata Pre processing function is finished executing - Here is its final output along with a code block (for R Studio users):",
       logfile = logfile,
-      code = 'chemdata.lrm.input <- chemdata_prep(chemdata.lrm.input, verbose = FALSE)',
+      code = 'chemdata.lrm.input <- chemdata_prep(chemdata.lrm.input)',
       verbose = verbose
     )
     create_download_link(data = chemdata.lrm.input, logfile = logfile, filename = 'LRM_PreProcessedInput.csv', linktext = 'Download Preprocessed Input to LRM Function (after calling chemdata_prep)', verbose = verbose)
@@ -532,7 +532,7 @@ CSI <- function(chemdata.csi.input, preprocessed = F, logfile = file.path(getwd(
     writelog(
       "\n#### Chemdata Pre processing function is finished executing - Here is its final output along with a code block (for R Studio users):",
       logfile = logfile,
-      code = 'chemdata.csi.input <- chemdata_prep(chemdata.csi.input, verbose = FALSE)',
+      code = 'chemdata.csi.input <- chemdata_prep(chemdata.csi.input)',
       verbose = verbose
     )
     create_download_link(data = chemdata.csi.input, logfile = logfile, filename = 'CSI_PreProcessedInput.csv', linktext = 'Download Preprocessed Input to CSI Function (after calling chemdata_prep)', verbose = verbose)
@@ -1043,7 +1043,7 @@ chem.sqo <- function(chemdata, logfile = file.path(getwd(), 'logs', format(Sys.t
   writelog(
     "\n## Chemdata Pre processing function is finished executing - Here is its final output along with a code block (for R Studio users):",
     logfile = logfile,
-    code = 'chemdata <- chemdata_prep(chemdata, verbose = FALSE)',
+    code = 'chemdata <- chemdata_prep(chemdata)',
     data = chemdata,
     verbose = verbose
   )
@@ -1078,7 +1078,7 @@ chem.sqo <- function(chemdata, logfile = file.path(getwd(), 'logs', format(Sys.t
   writelog(
     "#### Here is its final output along with a code block (for R Studio users):",
     logfile = logfile,
-    code = 'chemdata_lrm <- LRM(chemdata, preprocessed = TRUE,  verbose = FALSE)',
+    code = 'chemdata_lrm <- LRM(chemdata, preprocessed = TRUE)',
     data = chemdata_lrm,
     verbose = verbose
   )
@@ -1112,7 +1112,7 @@ chem.sqo <- function(chemdata, logfile = file.path(getwd(), 'logs', format(Sys.t
   writelog(
     "\n### Here is its final output along with a code block (for R Studio users):",
     logfile = logfile,
-    code = 'chemdata_csi <- CSI(chemdata, preprocessed = TRUE, verbose = FALSE)',
+    code = 'chemdata_csi <- CSI(chemdata, preprocessed = TRUE)',
     data = chemdata_csi,
     verbose = verbose
   )
@@ -1504,7 +1504,6 @@ chemdata_prep <- function(chemdata_prep.input, logfile = file.path(getwd(), 'log
       } else {
         msg <- \"Warning: Column 'labrep' was not provided - this may affect results if there are duplicate records for certain analytes\"
         warning(msg)
-        writelog(msg, logfile = logfile, verbose = verbose)
       }
 
       # Check for 'fieldrep' column
@@ -1514,7 +1513,6 @@ chemdata_prep <- function(chemdata_prep.input, logfile = file.path(getwd(), 'log
       } else {
         msg <- \"Warning: Column 'fieldrep' was not provided - this may affect results if there are duplicate records for certain analytes\"
         warning(msg)
-        writelog(msg, logfile = logfile, verbose = verbose)
       }
     ",
     data = chemdata_prep.input %>% head(15),

--- a/R/toxicity.R
+++ b/R/toxicity.R
@@ -161,7 +161,6 @@ tox.summary <- function(tox.summary.input, results.sampletypes = c('Grab'), cont
   # here we separate the controls from the rest of the samples
   controls <- tox.summary.input %>%
     filter(
-      stationid == '0000',
       (sampletypecode %in% control.sampletypes)
     )
 
@@ -211,7 +210,7 @@ tox.summary <- function(tox.summary.input, results.sampletypes = c('Grab'), cont
   # get rid of the controls. They will be merged later
   results <- tox.summary.input %>%
     filter(
-      ( (stationid != '0000') | (sampletypecode %in% results.sampletypes) )
+      sampletypecode %in% results.sampletypes
     )
 
   writelog(

--- a/R/toxicity.R
+++ b/R/toxicity.R
@@ -350,7 +350,18 @@ tox.summary <- function(tox.summary.input, results.sampletypes = c('Grab'), cont
       cv = stddev / pct_result,
       #n = n()
       # April 15, 2025 - let n be the number of not-null replicate result values
-      n = sum(!is.na(result))
+      n = sum(!is.na(result)),
+
+      # New - include these columns in the output summary table
+      # Set to NA_character if the columns are not included in the dataframe that we are grouping by.
+      # These columns may or may not be there in the original data
+      units = ifelse("units" %in% names(summary), paste(unique(summary[["units"]] %>% as.character() ), collapse = ';' ) ,  NA_character_),
+      endpoint = ifelse("endpoint" %in% names(summary), paste(unique(summary[["endpoint"]] %>% as.character() ), collapse = ';' ),  NA_character_),
+      qacode = ifelse("qacode" %in% names(summary), paste(unique(summary[["qacode"]] %>% as.character() ), collapse = ';' ),  NA_character_),
+      treatment = ifelse("treatment" %in% names(summary), paste(unique(summary[["treatment"]] %>% as.character() ), collapse = ';' ),  NA_character_),
+      comments = ifelse("comments" %in% names(summary), paste(unique(summary[["comments"]] %>% as.character() ), collapse = ';' ),  NA_character_),
+      dilution = ifelse("dilution" %in% names(summary), paste(unique(summary[["dilution"]] %>% as.character() ), collapse = ';' ),  NA_character_),
+      matrix = ifelse("matrix" %in% names(summary), paste(unique(summary[["matrix"]] %>% as.character() ), collapse = ';' ),  NA_character_)
     ) %>%
     ungroup() %>%
     mutate(
@@ -391,7 +402,14 @@ tox.summary <- function(tox.summary.input, results.sampletypes = c('Grab'), cont
           pct_result_adj = (pct_result / pct_control) * 100,
           stddev = sd(result, na.rm = T),
           cv = stddev / pct_result,
-          n = sum(!is.na(result))
+          n = sum(!is.na(result)),
+          units = ifelse(\"units\" %in% names(summary), paste(unique(summary[[\"units\"]] %>% as.character() ), collapse = ';' ) ,  NA_character_),
+          endpoint = ifelse(\"endpoint\" %in% names(summary), paste(unique(summary[[\"endpoint\"]] %>% as.character() ), collapse = ';' ),  NA_character_),
+          qacode = ifelse(\"qacode\" %in% names(summary), paste(unique(summary[[\"qacode\"]] %>% as.character() ), collapse = ';' ),  NA_character_),
+          treatment = ifelse(\"treatment\" %in% names(summary), paste(unique(summary[[\"treatment\"]] %>% as.character() ), collapse = ';' ),  NA_character_),
+          comments = ifelse(\"comments\" %in% names(summary), paste(unique(summary[[\"comments\"]] %>% as.character() ), collapse = ';' ),  NA_character_),
+          dilution = ifelse(\"dilution\" %in% names(summary), paste(unique(summary[[\"dilution\"]] %>% as.character() ), collapse = ';' ),  NA_character_),
+          matrix = ifelse(\"matrix\" %in% names(summary), paste(unique(summary[[\"matrix\"]] %>% as.character() ), collapse = ';' ),  NA_character_)
         ) %>%
         ungroup() %>%
         mutate(

--- a/R/toxicity.R
+++ b/R/toxicity.R
@@ -46,7 +46,7 @@
 
 # Version 0.3.0 update - allow a user to select sampletypes to include - allows QA to be included if a user so chooses
 # DEFAULT leave it out and do only grabs
-tox.summary <- function(tox.summary.input, results.sampletypes = c('Grab'), control.sampletypes = c('CNEG'), include.controls = F, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'ToxLog.Rmd' ), verbose = F) {
+tox.summary <- function(tox.summary.input, results.sampletypes = c('Grab'), control.sampletypes = c('CNEG'), include.controls = F, logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'ToxLog.Rmd' ), verbose = F, knitlog = F) {
 
   # Initialize Logging
   logfile.type <- ifelse(tolower(tools::file_ext(logfile)) == 'rmd', 'RMarkdown', 'text')
@@ -568,6 +568,26 @@ tox.summary <- function(tox.summary.input, results.sampletypes = c('Grab'), cont
 
   writelog('\n## END: Tox Summary function.\n', logfile = logfile, verbose = verbose)
 
+  if (verbose && knitlog) {
+    if ( tolower(tools::file_ext(logfile)) == 'rmd' ) {
+
+      html_file <- sub("\\.Rmd$", ".html", logfile, ignore.case = TRUE)
+
+      print(paste0("Rendering ", logfile, " to ", html_file))
+      rmarkdown::render(
+        input = logfile,
+        output_file = html_file,
+        output_format = "html_document",
+        quiet = TRUE
+      )
+      print("Done")
+
+    } else {
+      fn_name <- as.character(sys.call()[[1]])
+      warning(paste0("In '", fn_name, "': knitlog = TRUE but the logfile is not an R Markdown (.Rmd) file. Skipping knitting."))
+    }
+  }
+
   return(summary)
 }
 
@@ -609,7 +629,7 @@ tox.summary <- function(tox.summary.input, results.sampletypes = c('Grab'), cont
 #' tox.sqo(tox_sampledata)
 #'
 #' @export
-tox.sqo <- function(toxresults, results.sampletypes = c('Grab'), control.sampletypes = c('CNEG'), include.controls = F , logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'ToxLog.Rmd' ), verbose = F) {
+tox.sqo <- function(toxresults, results.sampletypes = c('Grab'), control.sampletypes = c('CNEG'), include.controls = F , logfile = file.path(getwd(), 'logs', format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), 'ToxLog.Rmd' ), verbose = F, knitlog = F) {
 
   logfile.type <- ifelse(tolower(tools::file_ext(logfile)) == 'rmd', 'RMarkdown', 'text')
   init.log(
@@ -985,8 +1005,27 @@ tox.sqo <- function(toxresults, results.sampletypes = c('Grab'), control.samplet
   )
   create_download_link(data = tox_final, logfile = logfile, filename = 'tox.sqo.final.csv', linktext = 'Download Final Tox SQO Data', verbose = verbose)
 
-
   writelog('\n# END: Tox SQO function.\n', logfile = logfile, verbose = verbose)
+
+  if (verbose && knitlog) {
+    if ( tolower(tools::file_ext(logfile)) == 'rmd' ) {
+
+      html_file <- sub("\\.Rmd$", ".html", logfile, ignore.case = TRUE)
+
+      print(paste0("Rendering ", logfile, " to ", html_file))
+      rmarkdown::render(
+        input = logfile,
+        output_file = html_file,
+        output_format = "html_document",
+        quiet = TRUE
+      )
+      print("Done")
+
+    } else {
+      fn_name <- as.character(sys.call()[[1]])
+      warning(paste0("In '", fn_name, "': knitlog = TRUE but the logfile is not an R Markdown (.Rmd) file. Skipping knitting."))
+    }
+  }
 
 
   return(tox_final)

--- a/R/utils.R
+++ b/R/utils.R
@@ -77,7 +77,7 @@ init.log <- function(
     is.base.func = T,
     verbose = F,
     title = 'Log',
-    libraries = c('rmarkdown','knitr','DT','tidyverse','SQOUnified')
+    libraries = c('rmarkdown','knitr','DT','dplyr','tidyr','stringr','SQOUnified')
 ) {
 
   logfile = path.expand(logfile)

--- a/man/init.log.Rd
+++ b/man/init.log.Rd
@@ -12,7 +12,7 @@ init.log(
   is.base.func = T,
   verbose = F,
   title = "Log",
-  libraries = c("rmarkdown", "knitr", "DT", "tidyverse", "SQOUnified")
+  libraries = c("rmarkdown", "knitr", "DT", "dplyr", "tidyr", "stringr", "SQOUnified")
 )
 }
 \arguments{

--- a/man/tox.summary.Rd
+++ b/man/tox.summary.Rd
@@ -33,8 +33,9 @@ tox.summary(toxresults)
 }
 \description{
 This function will calculate the tox summary,
-
-given an argument which is a dataframe of tox results data
+given an argument which is a dataframe of tox results data.
+By default, control samples will only be those with sampletypecode of CNEG. You may allow for others, such as CNSL.
+A warning will be issued if multiple controls are found within one batch
 }
 \examples{
 data(tox_sampledata)


### PR DESCRIPTION
Alters the way we handle controls in tox summary. Allows the user to select sampletypecodes to determine control samples vs the samples that contain the actual results.

Also adds a feature to knit the R Markdown log file automatically