### PR TITLE
Fix p-value calc for mismatched Laboratory Replicate Counts

### DIFF
--- a/R/toxicity.R
+++ b/R/toxicity.R
@@ -380,7 +380,10 @@ tox.summary <- function(tox.summary.input, results.sampletypes = c('Result'), co
     summarize(
       p = tryCatch({
         # it errors out when you pass two constant vectors as the first two arguments
-        t.test(x = result, y = result_control, mu = 0, var.equal = F, alternative = "two.sided")$p.value / 2
+        result_control_for_pvalue_calc = summary |>
+          dplyr::filter(toxbatch == 'Batch 3' & sampletypecode_control == 'CNEG') |>
+          select(result_control)
+        t.test(x = result, y = result_control_for_pvalue_calc, mu = 0, var.equal = F, alternative = "two.sided")$p.value / 2
       },
       warning = function(w){
         # If there was a warning, we still want the output of the function


### PR DESCRIPTION
## Background 

Sometimes the lab replicate counts do not match between controls and treatment samples. 

## Problem

The `group_by`:
https://github.com/SCCWRP/SQOUnified/blob/fa75d46207c20e0fbc090b897731d63de2804729/R/toxicity.R#L377-L379

This still splits the results and controls into two groups, so when there are 5 results and more than 5 controls, even though we have the full_join earlier in the code, we still only get the first 5 controls to go along with the results in the group for the `summarize` calculations (including the p-value, notably).

The `full_join` earlier in the code that was intended to fix this issue originally (in commit https://github.com/SCCWRP/SQOUnified/commit/4465315fbd137453497c38433e7e717cb9353503):

https://github.com/SCCWRP/SQOUnified/blob/fa75d46207c20e0fbc090b897731d63de2804729/R/toxicity.R#L234-L238

## Incomplete solution

This code change appears to produce the correct results based on looking at its effect for
```R
surveyyear == 2003 & toxbatch == "Batch 3" & stationid == 4076
```
but I do not think it introduces a good structural change to the code. We may want to do a more thorough refactoring to make it less abstruse.